### PR TITLE
[1.0.1] release 1.0.1 built with java8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Berbix Java library provides simple interfaces to interact with the Berbix 
 
 Install via Gradle
 
-    implementation 'com.berbix:berbix-java:1.0.0'
+    implementation 'com.berbix:berbix-java:1.0.1'
 
 Also available on [Maven](https://search.maven.org/artifact/com.berbix/berbix-java)
 

--- a/berbix-java/build.gradle
+++ b/berbix-java/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'signing'
 }
 
-version '1.0.0'
+version '1.0.1'
 group 'com.berbix'
 
 repositories {

--- a/berbix-java/build.gradle
+++ b/berbix-java/build.gradle
@@ -11,6 +11,11 @@ repositories {
     mavenCentral()
 }
 
+compileJava {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
+
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core:2.12.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.2'

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -8,6 +8,11 @@ repositories {
     mavenCentral()
 }
 
+compileJava {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
+
 dependencies {
     compile project(":berbix-java")
     implementation 'com.fasterxml.jackson.core:jackson-core:2.12.2'

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core:2.12.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.2'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/demo-app/src/main/java/com/berbix/demo/BerbixDemo.java
+++ b/demo-app/src/main/java/com/berbix/demo/BerbixDemo.java
@@ -7,7 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public class BerbixDemo {


### PR DESCRIPTION
Release v1.0.1 of berbix-java. 
No real code changes, just 1.0.0 had been inadvertently built with java 11. 