### PR TITLE
bump jetty version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ hs_err_pid*
 berbix-java/build
 demo-app/build
 .idea/
+.gradle/
+berbix-java/.gradle/
+berbix-java/.DS_Store

--- a/berbix-java/build.gradle
+++ b/berbix-java/build.gradle
@@ -2,9 +2,10 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'signing'
+    id 'java-library-distribution'
 }
 
-version '1.0.2'
+version '1.0.3'
 group 'com.berbix'
 
 repositories {
@@ -21,7 +22,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.2'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
-    implementation 'org.eclipse.jetty:jetty-client:9.4.38.v20210224'
+    implementation 'org.eclipse.jetty:jetty-client:9.4.49.v20220914'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
@@ -38,6 +39,7 @@ java {
 publishing {
     publications {
         berbixJava(MavenPublication) {
+            artifact distZip
             from components.java
 
             pom {


### PR DESCRIPTION
Bump jetty version to latest version in `9.4.x` to attempt to fix https://github.com/eclipse/jetty.project/issues/3891

Adds `java-library-distribution` plugin to generate libs report