### PR TITLE
add API only support to java sdk

### DIFF
--- a/berbix-java/build.gradle
+++ b/berbix-java/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'java-library-distribution'
 }
 
-version '1.1.0'
+version '1.2.0'
 group 'com.berbix'
 
 repositories {

--- a/berbix-java/src/main/java/com/berbix/BerbixApi.java
+++ b/berbix-java/src/main/java/com/berbix/BerbixApi.java
@@ -160,17 +160,21 @@ public class BerbixApi {
                 throw new BerbixException("Unable to create transaction", e);
             }
 
-            FetchTokensResponse fetchTokensResponse = null;
-            try {
-                fetchTokensResponse = objectMapper.readValue(apiResponseData, FetchTokensResponse.class);
-                fetchTokensResponse.responseJsonString = apiResponseData;
-            } catch (JsonProcessingException e) {
-                throw new BerbixException("Unable to create transaction", e);
-            } finally {
-                response.close();
-            }
+            if (response.isSuccessful()) {
+                FetchTokensResponse fetchTokensResponse = null;
+                try {
+                    fetchTokensResponse = objectMapper.readValue(apiResponseData, FetchTokensResponse.class);
+                    fetchTokensResponse.responseJsonString = apiResponseData;
+                } catch (JsonProcessingException e) {
+                    throw new BerbixException(apiResponseData);
+                } finally {
+                    response.close();
+                }
 
-            return fetchTokensResponse;
+                return fetchTokensResponse;
+            } else {
+                throw new BerbixException(apiResponseData);
+            }
         });
     }
 
@@ -240,7 +244,11 @@ public class BerbixApi {
             } else {
                 try {
                     responseData = response.body().string();
-                    return objectMapper.readValue(responseData, responseClass);
+                    if (response.isSuccessful()) {
+                        return objectMapper.readValue(responseData, responseClass);
+                    } else {
+                        throw new BerbixException(responseData);
+                    }
                 } catch (IOException e) {
                     throw new BerbixException("Unable to create transaction", e);
                 } finally {

--- a/berbix-java/src/main/java/com/berbix/BerbixApi.java
+++ b/berbix-java/src/main/java/com/berbix/BerbixApi.java
@@ -328,14 +328,14 @@ public class BerbixApi {
         }
     }
 
-    public CompletableFuture<UploadImagesResponse> uploadImagesAsync(Tokens tokens, UploadImagesRequest uploadImagesRequest) {
+    public CompletableFuture<UploadImagesResponse> uploadImagesAsync(String clientToken, UploadImagesRequest uploadImagesRequest) {
         if (uploadImagesRequest.images == null || uploadImagesRequest.images.isEmpty()) {
             CompletableFuture<UploadImagesResponse> completableFuture = new CompletableFuture<>();
             completableFuture.completeExceptionally(new BerbixException("Invalid uploadImagesRequest", new IllegalStateException()));
             return completableFuture;
         }
 
-        return tokenRequest("POST", tokens.clientToken, "/v0/images/upload", uploadImagesRequest, UploadImagesResponse.class)
+        return tokenRequest("POST", clientToken, "/v0/images/upload", uploadImagesRequest, UploadImagesResponse.class)
                 .handle((result, ex) -> {
                     if (ex != null) {
                         throw new BerbixException("Unable to upload images", ex);

--- a/berbix-java/src/main/java/com/berbix/BerbixApi.java
+++ b/berbix-java/src/main/java/com/berbix/BerbixApi.java
@@ -30,298 +30,335 @@ import java.util.concurrent.TimeUnit;
 
 public class BerbixApi {
 
-  private static final int REQUEST_TIMEOUT_MILLIS = 30000;
-  private final String apiSecret;
-  private final String apiHost;
-  private final OkHttpClient okHttpClient;
+    private static final int REQUEST_TIMEOUT_MILLIS = 30000;
+    private final String apiSecret;
+    private final String apiHost;
+    private final OkHttpClient okHttpClient;
 
-  private final ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-  public static final MediaType MEDIA_TYPE_JSON
-      = MediaType.parse("application/json; charset=utf-8");
+    public static final MediaType MEDIA_TYPE_JSON
+            = MediaType.parse("application/json; charset=utf-8");
 
-  public BerbixApi(String apiSecret, String apiHost) {
-    this.apiSecret = apiSecret;
-    this.apiHost = apiHost;
-    this.objectMapper = new ObjectMapper();
-    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    objectMapper.registerModule(new JavaTimeModule());
-    SimpleModule enumModule = new SimpleModule();
-    enumModule.addSerializer(OverrideTransactionRequest.ResponsePayload.class, new StdSerializer<OverrideTransactionRequest.ResponsePayload>(OverrideTransactionRequest.ResponsePayload.class) {
-      @Override
-      public void serialize(OverrideTransactionRequest.ResponsePayload value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        jgen.writeString(value.value);
-      }
-    });
-    objectMapper.registerModule(enumModule);
-
-    okHttpClient = new OkHttpClient.Builder()
-     .callTimeout(REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
-     .build();
-  }
-
-  void shutdown() {
-
-  }
-
-  public CompletableFuture<CreateTransactionResponse> createTransactionAsync(CreateTransactionRequest createTransactionRequest) {
-    return fetchTokens("/v0/transactions", createTransactionRequest)
-        .thenApply(fetchTokensResponse -> {
-          Tokens tokens = createTokens(fetchTokensResponse);
-
-          CreateTransactionResponse response = new CreateTransactionResponse();
-          response.tokens = tokens;
-          return response;
-        })
-        .handle((result, ex) -> {
-          if (ex != null) {
-            throw new BerbixException("Unable to create transaction", ex);
-          }
-
-          return result;
+    public BerbixApi(String apiSecret, String apiHost) {
+        this.apiSecret = apiSecret;
+        this.apiHost = apiHost;
+        this.objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.registerModule(new JavaTimeModule());
+        SimpleModule enumModule = new SimpleModule();
+        enumModule.addSerializer(OverrideTransactionRequest.ResponsePayload.class, new StdSerializer<OverrideTransactionRequest.ResponsePayload>(OverrideTransactionRequest.ResponsePayload.class) {
+            @Override
+            public void serialize(OverrideTransactionRequest.ResponsePayload value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+                jgen.writeString(value.value);
+            }
         });
-  }
+        objectMapper.registerModule(enumModule);
 
-  public CompletableFuture<CreateHostedTransactionResponse> createHostedTransactionAsync(CreateHostedTransactionRequest createHostedTransactionRequest) {
-    return fetchTokens("/v0/transactions", createHostedTransactionRequest)
-        .thenApply(fetchTokensResponse -> {
-          Tokens tokens = createTokens(fetchTokensResponse);
-
-          CreateHostedTransactionResponse response = new CreateHostedTransactionResponse();
-          response.tokens = tokens;
-          response.hostedUrl = fetchTokensResponse.hostedUrl;
-          return response;
-        })
-        .handle((result, ex) -> {
-          if (ex != null) {
-            throw new BerbixException("Unable to create hosted transaction", ex);
-          }
-
-          return result;
-        });
-  }
-
-  private Tokens createTokens(FetchTokensResponse fetchTokensResponse) {
-    Tokens tokens = new Tokens();
-    tokens.accessToken = fetchTokensResponse.accessToken;
-    tokens.clientToken = fetchTokensResponse.clientToken;
-    tokens.refreshToken = fetchTokensResponse.refreshToken;
-    tokens.transactionId = fetchTokensResponse.transactionId;
-    tokens.expiresAt = ZonedDateTime.now(ZoneId.of("UTC")).plus(fetchTokensResponse.expiresIn, ChronoUnit.SECONDS);
-    tokens.responseJsonString = fetchTokensResponse.responseJsonString;
-    return tokens;
-  }
-
-  private CompletableFuture<FetchTokensResponse> fetchTokens(String path, Object payload) {
-    Builder requestBuilder = new Request.Builder()
-      .url(apiHost + path)
-      .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((apiSecret + ":").getBytes(StandardCharsets.UTF_8)))
-      .addHeader("Content-Type", "application/json")
-      .addHeader("Accept", "application/json")
-      .addHeader("User-Agent", "BerbixJava/" + Berbix.BERBIX_SDK_VERSION);
-
-    Request request;
-
-    try {
-      request = requestBuilder
-        .post(RequestBody.create(MEDIA_TYPE_JSON, objectMapper.writeValueAsString(payload)))
-        .build();
-    } catch (JsonProcessingException e) {
-      throw new BerbixException("Unable to create transaction", e);
+        okHttpClient = new OkHttpClient.Builder()
+                .callTimeout(REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                .build();
     }
 
-    OkHttpResponseFuture callback = new OkHttpResponseFuture();
-    okHttpClient.newCall(request).enqueue(callback);
+    void shutdown() {
 
-    return callback.future.thenApply(response -> {
-      String apiResponseData;
-      try {
-        apiResponseData = response.body().string();
-      } catch (IOException e) {
-        throw new BerbixException("Unable to create transaction", e);
-      }
+    }
 
-      FetchTokensResponse fetchTokensResponse = null;
+    public CompletableFuture<CreateTransactionResponse> createTransactionAsync(CreateTransactionRequest createTransactionRequest) {
+        return fetchTokens("/v0/transactions", createTransactionRequest)
+                .thenApply(fetchTokensResponse -> {
+                    Tokens tokens = createTokens(fetchTokensResponse);
+
+                    CreateTransactionResponse response = new CreateTransactionResponse();
+                    response.tokens = tokens;
+                    return response;
+                })
+                .handle((result, ex) -> {
+                    if (ex != null) {
+                        throw new BerbixException("Unable to create transaction", ex);
+                    }
+
+                    return result;
+                });
+    }
+
+    public CompletableFuture<CreateHostedTransactionResponse> createHostedTransactionAsync(CreateHostedTransactionRequest createHostedTransactionRequest) {
+        return fetchTokens("/v0/transactions", createHostedTransactionRequest)
+                .thenApply(fetchTokensResponse -> {
+                    Tokens tokens = createTokens(fetchTokensResponse);
+
+                    CreateHostedTransactionResponse response = new CreateHostedTransactionResponse();
+                    response.tokens = tokens;
+                    response.hostedUrl = fetchTokensResponse.hostedUrl;
+                    return response;
+                })
+                .handle((result, ex) -> {
+                    if (ex != null) {
+                        throw new BerbixException("Unable to create hosted transaction", ex);
+                    }
+
+                    return result;
+                });
+    }
+
+    public CompletableFuture<CreateAPIOnlyTransactionResponse> createAPIOnlyTransactionAsync(CreateAPIOnlyTransactionRequest createAPIOnlyTransactionRequest) {
+        return fetchTokens("/v0/transactions", createAPIOnlyTransactionRequest)
+                .thenApply(fetchTokensResponse -> {
+                    Tokens tokens = createTokens(fetchTokensResponse);
+
+                    CreateAPIOnlyTransactionResponse response = new CreateAPIOnlyTransactionResponse();
+                    response.tokens = tokens;
+                    return response;
+                })
+                .handle((result, ex) -> {
+                    if (ex != null) {
+                        throw new BerbixException("Unable to create APIOnly transaction", ex);
+                    }
+
+                    return result;
+                });
+    }
+
+    private Tokens createTokens(FetchTokensResponse fetchTokensResponse) {
+        Tokens tokens = new Tokens();
+        tokens.accessToken = fetchTokensResponse.accessToken;
+        tokens.clientToken = fetchTokensResponse.clientToken;
+        tokens.refreshToken = fetchTokensResponse.refreshToken;
+        tokens.transactionId = fetchTokensResponse.transactionId;
+        tokens.expiresAt = ZonedDateTime.now(ZoneId.of("UTC")).plus(fetchTokensResponse.expiresIn, ChronoUnit.SECONDS);
+        tokens.responseJsonString = fetchTokensResponse.responseJsonString;
+        return tokens;
+    }
+
+    private CompletableFuture<FetchTokensResponse> fetchTokens(String path, Object payload) {
+        Builder requestBuilder = new Request.Builder()
+                .url(apiHost + path)
+                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((apiSecret + ":").getBytes(StandardCharsets.UTF_8)))
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json")
+                .addHeader("User-Agent", "BerbixJava/" + Berbix.BERBIX_SDK_VERSION);
+
+        Request request;
+
         try {
-          fetchTokensResponse = objectMapper.readValue(apiResponseData, FetchTokensResponse.class);
-          fetchTokensResponse.responseJsonString = apiResponseData;
+            request = requestBuilder
+                    .post(RequestBody.create(MEDIA_TYPE_JSON, objectMapper.writeValueAsString(payload)))
+                    .build();
         } catch (JsonProcessingException e) {
-          throw new BerbixException("Unable to create transaction", e);
-        } finally {
-          response.close();
+            throw new BerbixException("Unable to create transaction", e);
         }
 
-      return fetchTokensResponse;
-    });
-  }
+        OkHttpResponseFuture callback = new OkHttpResponseFuture();
+        okHttpClient.newCall(request).enqueue(callback);
 
-  public CompletableFuture<Transaction> fetchTransactionAsync(Tokens tokens) {
-    try {
-      return tokenAuthRequest("GET", tokens, "/v0/transactions", null, Transaction.class)
-          .handle((result, ex) -> {
-            if (ex != null) {
-              throw new BerbixException("Unable to fetch transaction", ex);
+        return callback.future.thenApply(response -> {
+            String apiResponseData;
+            try {
+                apiResponseData = response.body().string();
+            } catch (IOException e) {
+                throw new BerbixException("Unable to create transaction", e);
             }
 
-            return result;
-          });
-    } catch (IOException e) {
-      CompletableFuture<Transaction> completableFuture = new CompletableFuture<>();
-      completableFuture.completeExceptionally(new BerbixException("Unable to fetch transaction", e));
-      return completableFuture;
-    }
-  }
-
-  private <T> CompletableFuture<T> tokenAuthRequest(String method, Tokens tokens, String path, Object payload, Class<T> responseClass) throws IOException {
-    return refreshIfNecessaryAsync(tokens).thenCompose(newTokens -> {
-      Builder requestBuilder = new Request.Builder()
-        .url(apiHost + path)
-        .header("Authorization", "Bearer " + newTokens.accessToken)
-        .addHeader("Content-Type", "application/json")
-        .addHeader("Accept", "application/json")
-        .addHeader("User-Agent", "BerbixJava/" + Berbix.BERBIX_SDK_VERSION);
-
-      if (payload != null) {
-          try {
-            RequestBody reqBody = RequestBody.create(MEDIA_TYPE_JSON, objectMapper.writeValueAsString(payload));
-            switch (method) {
-                case "PUT":
-                  requestBuilder = requestBuilder.put(reqBody);
-                  break;
-                case "PATCH":
-                  requestBuilder = requestBuilder.patch(reqBody);
-                  break;
-                case "POST":
-                  requestBuilder = requestBuilder.post(reqBody);
-                  break;
+            FetchTokensResponse fetchTokensResponse = null;
+            try {
+                fetchTokensResponse = objectMapper.readValue(apiResponseData, FetchTokensResponse.class);
+                fetchTokensResponse.responseJsonString = apiResponseData;
+            } catch (JsonProcessingException e) {
+                throw new BerbixException("Unable to create transaction", e);
+            } finally {
+                response.close();
             }
-          } catch (JsonProcessingException e) {
-            throw new BerbixException("Unable to create transaction", e);
-          }
-      }
 
-      if (method == "DELETE") {
-        requestBuilder = requestBuilder.delete();
-      }
-
-      Request request = requestBuilder.build();
-
-      OkHttpResponseFuture callback = new OkHttpResponseFuture();
-      okHttpClient.newCall(request).enqueue(callback);
-
-      return callback.future.thenApply(response -> {
-        String responseData;
-
-        if (response.code() == 204 && responseClass == String.class) {
-          // cast string as String so T compiles.
-          return responseClass.cast("finished");
-        } else {
-          try {
-            responseData = response.body().string();
-            return objectMapper.readValue(responseData, responseClass);
-          } catch (IOException e) {
-            throw new BerbixException("Unable to create transaction", e);
-          } finally {
-            response.close();
-          }
-        }
-      });
-    });
-  }
-
-  private CompletableFuture<Tokens> refreshIfNecessaryAsync(Tokens tokens) {
-    if (tokens.needsRefresh()) {
-      return refreshTokensAsync(tokens)
-          .thenApply(newTokens -> {
-            tokens.refresh(newTokens);
-            return tokens;
-          });
-    } else {
-      return CompletableFuture.completedFuture(tokens);
-    }
-  }
-
-  public CompletableFuture<Tokens> refreshTokensAsync(Tokens tokens) {
-    RefreshTokenRequest request = new RefreshTokenRequest();
-    request.refreshToken = tokens.refreshToken;
-    request.grantType = "refresh_token";
-    return fetchTokens("/v0/tokens", request)
-        .thenApply(this::createTokens)
-        .handle((result, ex) -> {
-          if (ex != null) {
-            throw new BerbixException("Unable to refresh tokens", ex);
-          }
-
-          return result;
+            return fetchTokensResponse;
         });
-  }
+    }
 
-  public CompletableFuture<Boolean> overrideTransactionAsync(Tokens tokens, OverrideTransactionRequest request) {
-    try {
-      return tokenAuthRequest("PATCH", tokens, "/v0/transactions/override", request, String.class)
-          .handle((result, ex) -> {
-            if (ex != null) {
-              throw new BerbixException("Unable to override transaction", ex);
+    public CompletableFuture<Transaction> fetchTransactionAsync(Tokens tokens) {
+        try {
+            return tokenAuthRequest("GET", tokens, "/v0/transactions", null, Transaction.class)
+                    .handle((result, ex) -> {
+                        if (ex != null) {
+                            throw new BerbixException("Unable to fetch transaction", ex);
+                        }
+
+                        return result;
+                    });
+        } catch (IOException e) {
+            CompletableFuture<Transaction> completableFuture = new CompletableFuture<>();
+            completableFuture.completeExceptionally(new BerbixException("Unable to fetch transaction", e));
+            return completableFuture;
+        }
+    }
+
+    private <T> CompletableFuture<T> tokenAuthRequest(String method, Tokens tokens, String path, Object payload, Class<T> responseClass) throws IOException {
+        return refreshIfNecessaryAsync(tokens).thenCompose(newTokens -> tokenRequest(method, newTokens.accessToken, path, payload, responseClass));
+    }
+
+    private <T> CompletableFuture<T> tokenRequest(String method, String token, String path, Object payload, Class<T> responseClass) {
+        Builder requestBuilder = new Request.Builder()
+                .url(apiHost + path)
+                .header("Authorization", "Bearer " + token)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json")
+                .addHeader("User-Agent", "BerbixJava/" + Berbix.BERBIX_SDK_VERSION);
+
+        if (payload != null) {
+            try {
+                RequestBody reqBody = RequestBody.create(MEDIA_TYPE_JSON, objectMapper.writeValueAsString(payload));
+                switch (method) {
+                    case "PUT":
+                        requestBuilder = requestBuilder.put(reqBody);
+                        break;
+                    case "PATCH":
+                        requestBuilder = requestBuilder.patch(reqBody);
+                        break;
+                    case "POST":
+                        requestBuilder = requestBuilder.post(reqBody);
+                        break;
+                }
+            } catch (JsonProcessingException e) {
+                throw new BerbixException("Unable to create transaction", e);
             }
+        }
 
-            return true;
-          });
-    } catch (IOException e) {
-      CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
-      completableFuture.completeExceptionally(new BerbixException("Unable to override transaction", e));
-      return completableFuture;
-    }
-  }
+        if (method == "DELETE") {
+            requestBuilder = requestBuilder.delete();
+        }
 
-  public CompletableFuture<Transaction> updateTransactionAsync(Tokens tokens, UpdateTransactionRequest request) {
-    try {
-      return tokenAuthRequest("PATCH", tokens, "/v0/transactions", request, Transaction.class)
-          .handle((result, ex) -> {
-            if (ex != null) {
-              throw new BerbixException("Unable to update transaction", ex);
+        Request request = requestBuilder.build();
+
+        OkHttpResponseFuture callback = new OkHttpResponseFuture();
+        okHttpClient.newCall(request).enqueue(callback);
+
+        return callback.future.thenApply(response -> {
+            String responseData;
+
+            if (response.code() == 204 && responseClass == String.class) {
+                // cast string as String so T compiles.
+                return responseClass.cast("finished");
+            } else {
+                try {
+                    responseData = response.body().string();
+                    return objectMapper.readValue(responseData, responseClass);
+                } catch (IOException e) {
+                    throw new BerbixException("Unable to create transaction", e);
+                } finally {
+                    response.close();
+                }
             }
-
-            return result;
-          });
-    } catch (IOException e) {
-      CompletableFuture<Transaction> completableFuture = new CompletableFuture<>();
-      completableFuture.completeExceptionally(new BerbixException("Unable to update transaction", e));
-      return completableFuture;
-    }
-  }
-
-  public CompletableFuture<Boolean> deleteTransactionAsync(Tokens tokens) {
-    try {
-      return tokenAuthRequest("DELETE", tokens, "/v0/transactions", null, String.class)
-          .handle((result, ex) -> {
-            if (ex != null) {
-              throw new BerbixException("Unable to override transaction", ex);
-            }
-
-            return true;
-          });
-    } catch (IOException e) {
-      CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
-      completableFuture.completeExceptionally(new BerbixException("Unable to override transaction", e));
-      return completableFuture;
-    }
-  }
-
-  public class OkHttpResponseFuture implements Callback {
-    public final CompletableFuture<Response> future = new CompletableFuture<>();
-
-    public OkHttpResponseFuture() {
+        });
     }
 
-    @Override
-    public void onFailure(Call call, IOException e) {
-      future.completeExceptionally(e);
+    private CompletableFuture<Tokens> refreshIfNecessaryAsync(Tokens tokens) {
+        if (tokens.needsRefresh()) {
+            return refreshTokensAsync(tokens)
+                    .thenApply(newTokens -> {
+                        tokens.refresh(newTokens);
+                        return tokens;
+                    });
+        } else {
+            return CompletableFuture.completedFuture(tokens);
+        }
     }
 
-    @Override
-    public void onResponse(Call call, Response response) throws IOException {
-      future.complete(response);
+    public CompletableFuture<Tokens> refreshTokensAsync(Tokens tokens) {
+        RefreshTokenRequest request = new RefreshTokenRequest();
+        request.refreshToken = tokens.refreshToken;
+        request.grantType = "refresh_token";
+        return fetchTokens("/v0/tokens", request)
+                .thenApply(this::createTokens)
+                .handle((result, ex) -> {
+                    if (ex != null) {
+                        throw new BerbixException("Unable to refresh tokens", ex);
+                    }
+
+                    return result;
+                });
     }
-  }
+
+    public CompletableFuture<Boolean> overrideTransactionAsync(Tokens tokens, OverrideTransactionRequest request) {
+        try {
+            return tokenAuthRequest("PATCH", tokens, "/v0/transactions/override", request, String.class)
+                    .handle((result, ex) -> {
+                        if (ex != null) {
+                            throw new BerbixException("Unable to override transaction", ex);
+                        }
+
+                        return true;
+                    });
+        } catch (IOException e) {
+            CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
+            completableFuture.completeExceptionally(new BerbixException("Unable to override transaction", e));
+            return completableFuture;
+        }
+    }
+
+    public CompletableFuture<Transaction> updateTransactionAsync(Tokens tokens, UpdateTransactionRequest request) {
+        try {
+            return tokenAuthRequest("PATCH", tokens, "/v0/transactions", request, Transaction.class)
+                    .handle((result, ex) -> {
+                        if (ex != null) {
+                            throw new BerbixException("Unable to update transaction", ex);
+                        }
+
+                        return result;
+                    });
+        } catch (IOException e) {
+            CompletableFuture<Transaction> completableFuture = new CompletableFuture<>();
+            completableFuture.completeExceptionally(new BerbixException("Unable to update transaction", e));
+            return completableFuture;
+        }
+    }
+
+    public CompletableFuture<Boolean> deleteTransactionAsync(Tokens tokens) {
+        try {
+            return tokenAuthRequest("DELETE", tokens, "/v0/transactions", null, String.class)
+                    .handle((result, ex) -> {
+                        if (ex != null) {
+                            throw new BerbixException("Unable to override transaction", ex);
+                        }
+
+                        return true;
+                    });
+        } catch (IOException e) {
+            CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
+            completableFuture.completeExceptionally(new BerbixException("Unable to override transaction", e));
+            return completableFuture;
+        }
+    }
+
+    public CompletableFuture<UploadImagesResponse> uploadImagesAsync(Tokens tokens, UploadImagesRequest uploadImagesRequest) {
+        if (uploadImagesRequest.images == null || uploadImagesRequest.images.isEmpty()) {
+            CompletableFuture<UploadImagesResponse> completableFuture = new CompletableFuture<>();
+            completableFuture.completeExceptionally(new BerbixException("Invalid uploadImagesRequest", new IllegalStateException()));
+            return completableFuture;
+        }
+
+        return tokenRequest("POST", tokens.clientToken, "/v0/images/upload", uploadImagesRequest, UploadImagesResponse.class)
+                .handle((result, ex) -> {
+                    if (ex != null) {
+                        throw new BerbixException("Unable to upload images", ex);
+                    }
+
+                    return result;
+                });
+    }
+
+    public class OkHttpResponseFuture implements Callback {
+        public final CompletableFuture<Response> future = new CompletableFuture<>();
+
+        public OkHttpResponseFuture() {
+        }
+
+        @Override
+        public void onFailure(Call call, IOException e) {
+            future.completeExceptionally(e);
+        }
+
+        @Override
+        public void onResponse(Call call, Response response) throws IOException {
+            future.complete(response);
+        }
+    }
 }

--- a/berbix-java/src/main/java/com/berbix/BerbixClient.java
+++ b/berbix-java/src/main/java/com/berbix/BerbixClient.java
@@ -112,12 +112,12 @@ public class BerbixClient implements AutoCloseable {
     }
   }
 
-  public UploadImagesResponse uploadImages(Tokens tokens, UploadImagesRequest uploadImagesRequest) throws ExecutionException, InterruptedException {
-    return uploadImagesAsync(tokens, uploadImagesRequest).get();
+  public UploadImagesResponse uploadImages(String clientToken, UploadImagesRequest uploadImagesRequest) throws ExecutionException, InterruptedException {
+    return uploadImagesAsync(clientToken, uploadImagesRequest).get();
   }
 
-  public CompletableFuture<UploadImagesResponse> uploadImagesAsync(Tokens tokens, UploadImagesRequest uploadImagesRequest) {
-    return berbixAPI.uploadImagesAsync(tokens, uploadImagesRequest);
+  public CompletableFuture<UploadImagesResponse> uploadImagesAsync(String clientToken, UploadImagesRequest uploadImagesRequest) {
+    return berbixAPI.uploadImagesAsync(clientToken, uploadImagesRequest);
   }
 
   @Override

--- a/berbix-java/src/main/java/com/berbix/BerbixClient.java
+++ b/berbix-java/src/main/java/com/berbix/BerbixClient.java
@@ -31,6 +31,14 @@ public class BerbixClient implements AutoCloseable {
     return berbixAPI.createTransactionAsync(createTransactionRequest);
   }
 
+  public CreateAPIOnlyTransactionResponse createAPIOnlyTransaction(CreateAPIOnlyTransactionRequest createAPIOnlyTransactionRequest) throws ExecutionException, InterruptedException {
+    return createAPIOnlyTransactionAsync(createAPIOnlyTransactionRequest).get();
+  }
+
+  public CompletableFuture<CreateAPIOnlyTransactionResponse> createAPIOnlyTransactionAsync(CreateAPIOnlyTransactionRequest createAPIOnlyTransactionRequest) {
+    return berbixAPI.createAPIOnlyTransactionAsync(createAPIOnlyTransactionRequest);
+  }
+
   public CreateHostedTransactionResponse createHostedTransaction(CreateHostedTransactionRequest createHostedTransactionRequest) throws ExecutionException, InterruptedException {
     return createHostedTransactionAsync(createHostedTransactionRequest).get();
   }
@@ -102,6 +110,14 @@ public class BerbixClient implements AutoCloseable {
     } catch (NoSuchAlgorithmException | InvalidKeyException e) {
       return false;
     }
+  }
+
+  public UploadImagesResponse uploadImages(Tokens tokens, UploadImagesRequest uploadImagesRequest) throws ExecutionException, InterruptedException {
+    return uploadImagesAsync(tokens, uploadImagesRequest).get();
+  }
+
+  public CompletableFuture<UploadImagesResponse> uploadImagesAsync(Tokens tokens, UploadImagesRequest uploadImagesRequest) {
+    return berbixAPI.uploadImagesAsync(tokens, uploadImagesRequest);
   }
 
   @Override

--- a/berbix-java/src/main/java/com/berbix/BerbixException.java
+++ b/berbix-java/src/main/java/com/berbix/BerbixException.java
@@ -2,6 +2,10 @@ package com.berbix;
 
 public class BerbixException extends RuntimeException {
 
+  public BerbixException(String message) {
+    super(message);
+  }
+
   public BerbixException(String message, Throwable e) {
     super(message, e);
   }

--- a/berbix-java/src/main/java/com/berbix/CreateAPIOnlyTransactionRequest.java
+++ b/berbix-java/src/main/java/com/berbix/CreateAPIOnlyTransactionRequest.java
@@ -1,0 +1,15 @@
+package com.berbix;
+
+public class CreateAPIOnlyTransactionRequest {
+    public String customerUid;
+    public String templateKey;
+    public String phone;
+    public String email;
+    public boolean consentsToAutomatedFacialRecognition;
+    public CreateAPIOnlyTransactionRequest.APIOnlyOptions apiOnlyOptions = new CreateAPIOnlyTransactionRequest.APIOnlyOptions();
+
+    public static class APIOnlyOptions {
+        public String idCountry;
+        public String idType;
+    }
+}

--- a/berbix-java/src/main/java/com/berbix/CreateAPIOnlyTransactionResponse.java
+++ b/berbix-java/src/main/java/com/berbix/CreateAPIOnlyTransactionResponse.java
@@ -1,0 +1,5 @@
+package com.berbix;
+
+public class CreateAPIOnlyTransactionResponse {
+    public Tokens tokens;
+}

--- a/berbix-java/src/main/java/com/berbix/CreateHostedTransactionRequest.java
+++ b/berbix-java/src/main/java/com/berbix/CreateHostedTransactionRequest.java
@@ -5,6 +5,7 @@ public class CreateHostedTransactionRequest {
   public String templateKey;
   public String phone;
   public String email;
+  public boolean consentsToAutomatedFacialRecognition;
   public HostedOptions hostedOptions = new HostedOptions();
 
   public static class HostedOptions {

--- a/berbix-java/src/main/java/com/berbix/CreateTransactionRequest.java
+++ b/berbix-java/src/main/java/com/berbix/CreateTransactionRequest.java
@@ -5,4 +5,5 @@ public class CreateTransactionRequest {
   public String templateKey;
   public String phone;
   public String email;
+  public boolean consentsToAutomatedFacialRecognition;
 }

--- a/berbix-java/src/main/java/com/berbix/UploadImagesRequest.java
+++ b/berbix-java/src/main/java/com/berbix/UploadImagesRequest.java
@@ -1,0 +1,37 @@
+package com.berbix;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UploadImagesRequest {
+    public static final String ImageSubjectDocumentFront = "document_front";
+    public static final String ImageSubjectDocumentBack = "document_back";
+    public static final String ImageSubjectDocumentBarcode = "document_barcode";
+    public static final String ImageSubjectSelfieFront = "selfie_front";
+    public static final String ImageSubjectSelfieLeft = "selfie_left";
+    public static final String ImageSubjectSelfieRight = "selfie_right";
+
+    public static final String ImageFormatPNG = "image/png";
+    public static final String ImageFormatJPEG = "image/jpeg";
+
+    public List<ImageData> images = new ArrayList<>();
+
+    public static class ImageData {
+        // base 64 encoded string of image
+        public String data;
+        public String imageSubject;
+        public String format;
+        public SupplementaryData supplementaryData;
+
+        public static class SupplementaryData {
+            public ExtractedBarcode extractedBarcode;
+
+            public static class ExtractedBarcode {
+                public String barcodeType;
+                public String extractedData;
+            }
+        }
+    }
+}
+
+

--- a/berbix-java/src/main/java/com/berbix/UploadImagesResponse.java
+++ b/berbix-java/src/main/java/com/berbix/UploadImagesResponse.java
@@ -1,0 +1,32 @@
+package com.berbix;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class UploadImagesResponse {
+    public static final String NextStepUploadDocumentFront = "upload_document_front";
+    public static final String NextStepUploadDocumentBack = "upload_document_back";
+    public static final String NextStepUploadSelfieBasic = "upload_selfie_basic";
+    public static final String NextStepUploadSelfieLiveness = "upload_selfie_liveness";
+    // NextStepDone indicates that no more uploads are expected.
+    public static final String NextStepDone = "done";
+
+    public static final String IssueBadUpload = "bad_upload";
+    public static final String IssueTextUnreadable = "text_unreadable";
+    public static final String IssueNoFaceOnIDDetected = "no_face_on_id_detected";
+    public static final String IssueIncompleteBarcodeDetected = "incomplete_barcode_detected";
+    public static final String IssueUnsupportedIDType = "unsupported_id_type";
+    public static final String IssueBadSelfie = "bad_selfie";
+
+    public String[] issues;
+    public IssueDetails issueDetails;
+    public String nextStep;
+
+    public static class IssueDetails {
+        @JsonProperty("unsupported_id_type")
+        public static UnsupportedIDTypeDetails unsupportedIDType;
+
+        public static class UnsupportedIDTypeDetails {
+            public boolean visaPageOfPassport;
+        }
+    }
+}

--- a/demo-app/src/main/java/com/berbix/demo/APIOnlyDemo.java
+++ b/demo-app/src/main/java/com/berbix/demo/APIOnlyDemo.java
@@ -1,0 +1,107 @@
+package com.berbix.demo;
+
+import com.berbix.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+public class APIOnlyDemo {
+
+    public static void main(String[] args) throws JsonProcessingException, ExecutionException, InterruptedException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        objectMapper.registerModule(new JavaTimeModule());
+
+        BerbixClient berbixClient = Berbix.create(
+                new Berbix.BerbixOptions.Builder()
+                        .apiSecret("YOUR_API_SECRET_HERE_DO_NOT_PUT_IN_SOURCE_CODE")
+                        .build());
+        try {
+            CreateAPIOnlyTransactionRequest request = new CreateAPIOnlyTransactionRequest();
+            request.customerUid = UUID.randomUUID().toString();
+            request.templateKey = "YOUR_TEMPLATE_KEY_HERE";
+            request.consentsToAutomatedFacialRecognition = true;
+            request.apiOnlyOptions = new CreateAPIOnlyTransactionRequest.APIOnlyOptions();
+
+            System.out.println("creating API transaction transaction");
+            CreateAPIOnlyTransactionResponse response = berbixClient.createAPIOnlyTransaction(request);
+            System.out.println(objectMapper.writeValueAsString(response));
+
+            UploadImagesResponse imagesResponse;
+
+            UploadImagesRequest.ImageData imageData;
+            imageData = createImageData("PATH_TO_FRONT_IMAGE",
+                    UploadImagesRequest.ImageSubjectDocumentFront);
+
+            System.out.println("uploading front");
+            imagesResponse = uploadImages(berbixClient,
+                    response.tokens,
+                    Collections.singletonList(imageData));
+
+            System.out.println(objectMapper.writeValueAsString(imagesResponse));
+
+
+            imageData = createImageData("PATH_TO_BACK_IMAGE",
+                    UploadImagesRequest.ImageSubjectDocumentBack);
+
+            System.out.println("uploading back");
+            imagesResponse = uploadImages(berbixClient,
+                    response.tokens,
+                    Collections.singletonList(imageData));
+
+            System.out.println(objectMapper.writeValueAsString(imagesResponse));
+
+
+            imageData = createImageData("PATH_TO_SELFIE_IMAGE",
+                    UploadImagesRequest.ImageSubjectSelfieFront);
+            System.out.println("uploading selfie");
+            imagesResponse = uploadImages(berbixClient,
+                    response.tokens,
+                    Collections.singletonList(imageData));
+
+            System.out.println(objectMapper.writeValueAsString(imagesResponse));
+
+            System.out.println("fetch transaction");
+            Transaction transactionResponse = berbixClient.fetchTransaction(response.tokens);
+            System.out.println(objectMapper.writeValueAsString(transactionResponse));
+
+        } catch (Exception e) {
+            System.out.println(e);
+        } finally {
+            berbixClient.close();
+        }
+    }
+
+    private static UploadImagesRequest.ImageData createImageData(String imagePath, String subject) throws IOException {
+        File imageFile = new File(imagePath);
+        FileInputStream fileInputStreamReader = new FileInputStream(imageFile);
+        byte[] bytes = new byte[(int) imageFile.length()];
+        fileInputStreamReader.read(bytes);
+        String encodedImage = Base64.getEncoder().encodeToString(bytes);
+
+        UploadImagesRequest.ImageData imageData = new UploadImagesRequest.ImageData();
+        imageData.data = encodedImage;
+        imageData.imageSubject = subject;
+        imageData.format = UploadImagesRequest.ImageFormatJPEG;
+
+        return imageData;
+    }
+
+    private static UploadImagesResponse uploadImages(BerbixClient berbixClient, Tokens tokens, List<UploadImagesRequest.ImageData> imageData) throws IOException, ExecutionException, InterruptedException {
+        UploadImagesRequest uploadImagesRequest = new UploadImagesRequest();
+        uploadImagesRequest.images = imageData;
+
+        return berbixClient.uploadImages(tokens, uploadImagesRequest);
+    }
+}

--- a/demo-app/src/main/java/com/berbix/demo/APIOnlyDemo.java
+++ b/demo-app/src/main/java/com/berbix/demo/APIOnlyDemo.java
@@ -46,7 +46,7 @@ public class APIOnlyDemo {
 
             System.out.println("uploading front");
             imagesResponse = uploadImages(berbixClient,
-                    response.tokens,
+                    response.tokens.clientToken,
                     Collections.singletonList(imageData));
 
             System.out.println(objectMapper.writeValueAsString(imagesResponse));
@@ -57,7 +57,7 @@ public class APIOnlyDemo {
 
             System.out.println("uploading back");
             imagesResponse = uploadImages(berbixClient,
-                    response.tokens,
+                    response.tokens.clientToken,
                     Collections.singletonList(imageData));
 
             System.out.println(objectMapper.writeValueAsString(imagesResponse));
@@ -67,7 +67,7 @@ public class APIOnlyDemo {
                     UploadImagesRequest.ImageSubjectSelfieFront);
             System.out.println("uploading selfie");
             imagesResponse = uploadImages(berbixClient,
-                    response.tokens,
+                    response.tokens.clientToken,
                     Collections.singletonList(imageData));
 
             System.out.println(objectMapper.writeValueAsString(imagesResponse));
@@ -98,10 +98,10 @@ public class APIOnlyDemo {
         return imageData;
     }
 
-    private static UploadImagesResponse uploadImages(BerbixClient berbixClient, Tokens tokens, List<UploadImagesRequest.ImageData> imageData) throws IOException, ExecutionException, InterruptedException {
+    private static UploadImagesResponse uploadImages(BerbixClient berbixClient, String clientToken, List<UploadImagesRequest.ImageData> imageData) throws IOException, ExecutionException, InterruptedException {
         UploadImagesRequest uploadImagesRequest = new UploadImagesRequest();
         uploadImagesRequest.images = imageData;
 
-        return berbixClient.uploadImages(tokens, uploadImagesRequest);
+        return berbixClient.uploadImages(clientToken, uploadImagesRequest);
     }
 }

--- a/demo-app/src/main/java/com/berbix/demo/APIOnlyDemo.java
+++ b/demo-app/src/main/java/com/berbix/demo/APIOnlyDemo.java
@@ -34,7 +34,7 @@ public class APIOnlyDemo {
             request.consentsToAutomatedFacialRecognition = true;
             request.apiOnlyOptions = new CreateAPIOnlyTransactionRequest.APIOnlyOptions();
 
-            System.out.println("creating API transaction transaction");
+            System.out.println("creating API transaction");
             CreateAPIOnlyTransactionResponse response = berbixClient.createAPIOnlyTransaction(request);
             System.out.println(objectMapper.writeValueAsString(response));
 
@@ -78,6 +78,7 @@ public class APIOnlyDemo {
 
         } catch (Exception e) {
             System.out.println(e);
+            System.out.println(e.getCause().getCause());
         } finally {
             berbixClient.close();
         }


### PR DESCRIPTION
- Add API only support to java SDK
- bump to version 1.2.0
- add demo for API only 

```
Task :demo-app:APIOnlyDemo.main()
creating API transaction transaction
{"tokens":<REDACTED>}
uploading front
{"issues":[],"issue_details":{},"next_step":"upload_document_back"}
uploading back
{"issues":[],"issue_details":{},"next_step":"upload_selfie_basic"}
uploading selfie
{"issues":[],"issue_details":{},"next_step":"done"}
fetch transaction
<REDACTED>
```